### PR TITLE
FIX: Switching to sepolia issue

### DIFF
--- a/src/components/ConnectWallet.tsx
+++ b/src/components/ConnectWallet.tsx
@@ -145,6 +145,9 @@ export default function ConnectWallet() {
         console.log('Event: accountsChanged', accounts);
         if (accounts.length > 0) {
           updateAddress(accounts[0])
+          if (rawProvider) {
+            await setupProviderConnection(rawProvider);
+          }
         } else {
           disconnectWallet();
         }
@@ -153,6 +156,9 @@ export default function ConnectWallet() {
       const onChainChangedHandler = async (chainIdHex: string) => {
         console.log('Event: chainChanged, new chainIdHex:', chainIdHex);
         const isSepoliaNetwork = chainIdHex === SEPOLIA_CHAIN_ID_HEX;
+        if (rawProvider) {
+          await setupProviderConnection(rawProvider);
+        }
         setIsSepolia(isSepoliaNetwork);
         updateChainId(BigInt(chainIdHex));
       };


### PR DESCRIPTION
The problem was that when switching to Sepolia, the necessary objects were not recreated. Because of this, the application thought that we were in mainnet, for example, although in MetaMask everything was displayed correctly and the transaction was successfully executed but applications show error message. Now it's fixed